### PR TITLE
Support for Gnome Shell 3.36

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -9,6 +9,7 @@ const Slider = imports.ui.slider;
 const PanelMenu = imports.ui.panelMenu;
 const Me = imports.misc.extensionUtils.getCurrentExtension();
 const Config = imports.misc.config;
+const GObject = imports.gi.GObject;
 
 var _version;
 
@@ -24,11 +25,11 @@ var reloadApps = false;
 let _function;
 let _signal = [];
 
-class ColumnsMenu extends PanelMenu.SystemIndicator
+var ColumnsMenu = class ColumnsMenu extends PanelMenu.SystemIndicator
 {
-    constructor()
+    _init()
     {
-        super();
+        super._init();
 
         this.buttonMenu = new PopupMenu.PopupBaseMenuItem({reactive: true});
 
@@ -138,6 +139,12 @@ function init()
     _settings = new Gio.Settings({ settings_schema: schemaObj });
 
     _version = parseInt(Config.PACKAGE_VERSION.split('.')[1]);
+
+    if (_version > 34)
+        ColumnsMenu = GObject.registerClass(
+            {GTypeName: 'ColumnsMenu'},
+            ColumnsMenu
+        );
 }
 
 function enable()

--- a/metadata.json
+++ b/metadata.json
@@ -3,11 +3,11 @@
   "description": "Set the number of columns in the Applications Overview. Controlled by a slider in the system menu with a switch for increasing compactness for up to 12 columns.", 
   "name": "Application View Columns", 
   "shell-version": [
-    "3.30",
-    "3.32",
+    "3.30", 
+    "3.32", 
     "3.34"
   ], 
   "url": "https://github.com/fawtytoo/app-view-columns", 
   "uuid": "app_view_columns@fawtytoo", 
-  "version": 6
+  "version": 7
 }


### PR DESCRIPTION
Migrating from Native to GObject:
Wrapping the ColumnsMenu class in GObject.registerClass() and adjusting the constructor function to use _init()